### PR TITLE
docs: update Valora and Mento links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This repository contains the Core Contracts for the Celo Blockchain. Most Celo p
 - **Developer Tooling**: [celo-org/developer-tooling](https://github.com/celo-org/developer-tooling)
 - **Helm Charts**: [celo-org/charts](https://github.com/celo-org/charts)
 - **SocialConnect**: [celo-org/social-connect](https://github.com/celo-org/social-connect)
-- **Valora Wallet**: [valora-inc](https://github.com/valora-inc)
-- **Mento Protocol**: [mento-protocol](https://github.com/mento-protocol)
+- **Valora Wallet**: [valora-inc](https://github.com/valora-inc) (https://www.valora.xyz/)
+- **Mento Protocol**: [mento-protocol](https://github.com/mento-protocol) (https://www.mento.org/)
 
 For a full list of Celo repositories, visit the [Celo GitHub organization](https://github.com/celo-org).
 


### PR DESCRIPTION
- Replaced old GitHub-only references for Valora and Mento
- Added official website links:
   - Valora: https://www.valora.xyz/
   - Mento: https://www.mento.org/
- Improves documentation accuracy and user experience

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_